### PR TITLE
Testing on PyPI resulted in stricter dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+0.3.1 (2019-07-25)
+------------------
+- Testing on PyPI resulted in stricter dependencies
+
 0.3 (2019-07-25)
 ----------------
 - Code changed to Python 3 only

--- a/Pipfile
+++ b/Pipfile
@@ -4,8 +4,8 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-"ruamel.yaml" = "*"
-dploy = "*"
+"ruamel.yaml" = ">=0.15.100"
+dploy = ">=0.1.2"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4ec3fc89c8adfb3e43773782c36f5c244696867ab300ddeeb90db277d8191d09"
+            "sha256": "daec1e9127fb370e5de0ff9cc86d6b1e99ddb0853c0d23dc6acd7c6288d19eea"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/dotsecrets/metadata.py
+++ b/dotsecrets/metadata.py
@@ -1,6 +1,6 @@
 from datetime import datetime as dt
 
-__version_info__ = (0, 3, 0)
+__version_info__ = (0, 3, 1, 'rc1')
 __version__ = '.'.join(map(str, __version_info__))
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ with open(os.path.join(HERE, 'CHANGES.rst'), encoding='utf-8') as f:
 PACKAGES = find_packages(exclude=['tests'])
 
 REQUIRES = [
-    'ruamel.yaml',
-    'dploy',
+    'ruamel.yaml>=0.15.100',
+    'dploy>=0.1.2',
 ]
 
 META = {}


### PR DESCRIPTION
And lesson learned to use pre-release versions as test PyPI does
not allow uploading with the same version.