### PR TITLE
Fix 'str' object has no attribute 'open' when using --filters or --store

### DIFF
--- a/dotsecrets/main.py
+++ b/dotsecrets/main.py
@@ -3,6 +3,8 @@ import argparse
 import logging
 import sys
 
+from pathlib import Path
+
 from dotsecrets.clean import clean
 from dotsecrets.init import init
 from dotsecrets.metadata import VERSION
@@ -54,11 +56,11 @@ def main():
 
     filter_parser = argparse.ArgumentParser(add_help=False)
     filter_parser.add_argument('--filters', metavar='FILE',
-                               help='load filters from FILE')
+                               help='load filters from FILE', type=Path)
 
     store_parser = argparse.ArgumentParser(add_help=False)
     store_parser.add_argument('--store', metavar='FILE',
-                              help='load secrets from FILE')
+                              help='load secrets from FILE', type=Path)
 
     init_cmd_parser = subparsers.add_parser('init',
                                             help='initialize fresh Git '


### PR DESCRIPTION
When using --filters or --store options to specify a file location, the open function is called on a string instead of a Path object.

```
Traceback (most recent call last):
  File "dotsecrets/main.py", line 124, in main
    return args.func(args)
  File "dotsecrets/test.py", line 66, in test
    clean_filter = get_clean_filter(args.name, args.filters)
  File "dotsecrets/clean.py", line 130, in get_clean_filter
    filters_dict, filters_file = load_all_filters(filters_file)
  File "dotsecrets/clean.py", line 122, in load_all_filters
    with filters_file.open(mode='r', encoding='utf-8') as f:
AttributeError: 'str' object has no attribute 'open'
```